### PR TITLE
Changes needed for syntax highlighting

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -11,12 +11,9 @@ fn main() {
     c_config.file(&parser_path);
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
-    // NOTE: if your language uses an external scanner, uncomment this block:
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("tree-sitter-wesl");
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -36,9 +36,9 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]


### PR DESCRIPTION
Used in wesldoc [here](https://github.com/jannik4/wesldoc/blob/2f605fc5dc673c55b22cfb3be3204ca15193ab50/crates/wesldoc_generator/src/syntax.rs)